### PR TITLE
Pitch name refactor

### DIFF
--- a/DroneOn/Base.lproj/Main.storyboard
+++ b/DroneOn/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="49e-Tb-3d3">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="49e-Tb-3d3">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>

--- a/DroneOn/Models/PitchNames.h
+++ b/DroneOn/Models/PitchNames.h
@@ -12,6 +12,21 @@
 
 @property (strong, nonatomic) NSArray *pitches;
 
+typedef enum Pitches{
+    Cnatural,
+    Csharp,
+    Dnatural,
+    Eflat,
+    Enatural,
+    Fnatural,
+    Fsharp,
+    Gnatural,
+    Gsharp,
+    Anatural,
+    Bflat,
+    Bnatural
+}Pitches;
+
 -(int)pitchNameToMidi:(NSString *)selectedPitch;
 -(int)octaveNameToInt:(NSString *)selectedOctave;
 

--- a/DroneOn/Models/PitchNames.h
+++ b/DroneOn/Models/PitchNames.h
@@ -12,21 +12,6 @@
 
 @property (strong, nonatomic) NSArray *pitches;
 
-typedef enum Pitches{
-    Cnatural,
-    Csharp,
-    Dnatural,
-    Eflat,
-    Enatural,
-    Fnatural,
-    Fsharp,
-    Gnatural,
-    Gsharp,
-    Anatural,
-    Bflat,
-    Bnatural
-}Pitches;
-
 -(int)pitchNameToMidi:(NSString *)selectedPitch;
 -(int)octaveNameToInt:(NSString *)selectedOctave;
 

--- a/DroneOn/Models/PitchNames.m
+++ b/DroneOn/Models/PitchNames.m
@@ -14,25 +14,25 @@
    
     if ([selectedPitch isEqualToString:@"C"]) {
         return 36;
-    } else if ([selectedPitch isEqualToString:@"C#/Db"]) {
+    } else if ([selectedPitch isEqualToString:@"C#"]) {
         return 37;
     } else if ([selectedPitch isEqualToString:@"D"]) {
         return 38;
-    } else if ([selectedPitch isEqualToString:@"D#/Eb"]) {
+    } else if ([selectedPitch isEqualToString:@"Eb"]) {
         return 39;
     } else if ([selectedPitch isEqualToString:@"E"]) {
         return 40;
     } else if ([selectedPitch isEqualToString:@"F"]) {
         return 41;
-    } else if ([selectedPitch isEqualToString:@"F#/Gb"]) {
+    } else if ([selectedPitch isEqualToString:@"F#"]) {
         return 42;
     } else if ([selectedPitch isEqualToString:@"G"]) {
         return 43;
-    } else if ([selectedPitch isEqualToString:@"G#/Ab"]) {
+    } else if ([selectedPitch isEqualToString:@"G#"]) {
         return 44;
     } else if ([selectedPitch isEqualToString:@"A"]) {
         return 45;
-    } else if ([selectedPitch isEqualToString:@"A#/Bb"]) {
+    } else if ([selectedPitch isEqualToString:@"Bb"]) {
         return 46;
     } else if ([selectedPitch isEqualToString:@"B"]) {
         return 47;
@@ -61,8 +61,7 @@
     self = [super init];
     if (self) {
         _pitches = @[
-                     @[@"C", @"C#/Db",@"D", @"D#/Eb", @"E", @"F", @"F#/Gb",
-                       @"G", @"G#/Ab", @"A", @"A#/Bb", @"B"],
+                     @[@"C", @"C#",@"D", @"Eb", @"E", @"F", @"F#", @"G", @"G#", @"A", @"Bb", @"B"],
                      @[@"1",@"2",@"3",@"4",@"5"]
                      ];
     }

--- a/DroneOn/Models/PitchNames.m
+++ b/DroneOn/Models/PitchNames.m
@@ -11,6 +11,7 @@
 @implementation PitchNames
 
 -(int)pitchNameToMidi:(NSString *)selectedPitch{
+   
     if ([selectedPitch isEqualToString:@"C"]) {
         return 36;
     } else if ([selectedPitch isEqualToString:@"C#/Db"]) {


### PR DESCRIPTION
Decided against modifying the code to use an enum.  Even though the syntax for the pitch to midi function since switching on NSString is not possible, it is still clear and functional. Just changed the note names to be neater.
